### PR TITLE
Method to inject encoding/csv.Reader

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -73,6 +73,23 @@ func Unmarshal(doc []byte, v interface{}) error {
 	return nil
 }
 
+func UnmarshalReader(reader *csv.Reader, v interface{}) error {
+	rv, err := checkForSlice(v)
+
+	if err != nil {
+		return err
+	}
+
+	dec, err := newDecoderReader(reader, rv)
+
+	if err != nil {
+		return err
+	}
+
+	dec.unmarshal()
+	return nil
+}
+
 func (dec *decoder) unmarshal() error {
 	for {
 		raw, err := dec.csv.Read()
@@ -204,8 +221,13 @@ func exportedFields(t reflect.Type) []*reflect.StructField {
 func newDecoder(doc []byte, rv reflect.Value) (*decoder, error) {
 	b := bytes.NewReader(doc)
 	r := csv.NewReader(b)
-	cols, err := r.Read()
 
+	return newDecoderReader(r, rv)
+}
+
+func newDecoderReader(r *csv.Reader, rv reflect.Value) (*decoder, error) {
+
+	cols, err := r.Read()
 	if err != nil {
 		return nil, err
 	}

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,7 +1,9 @@
 package csv
 
 import (
+	"encoding/csv"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -141,5 +143,28 @@ Jay,23`
 
 	if oo[0].Name.V != "Jay 23" {
 		t.Errorf("custom unmarshal did not work (%s)", oo[0].Name.V)
+	}
+}
+
+type UR struct {
+	Name string `csv:"Name"`
+	Age  string `csv:"Age"`
+}
+
+func TestUnmarshalReader(t *testing.T) {
+	doc := `Name|Age
+James|39`
+
+	reader := csv.NewReader(strings.NewReader(doc))
+	reader.Comma = '|'
+
+	var oo []UR
+
+	if err := UnmarshalReader(reader, &oo); err != nil {
+		t.Fail()
+	}
+
+	if oo[0].Name != `James` {
+		t.Fail()
 	}
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -151,12 +151,32 @@ type UR struct {
 	Age  string `csv:"Age"`
 }
 
-func TestUnmarshalReader(t *testing.T) {
+func TestUnmarshalReaderPipes(t *testing.T) {
 	doc := `Name|Age
 James|39`
 
 	reader := csv.NewReader(strings.NewReader(doc))
 	reader.Comma = '|'
+
+	var oo []UR
+
+	if err := UnmarshalReader(reader, &oo); err != nil {
+		t.Fail()
+	}
+
+	if oo[0].Name != `James` {
+		t.Fail()
+	}
+}
+
+
+func TestUnmarshalReaderSpaces(t *testing.T) {
+	doc := `Name   Age
+"James"             39`
+
+	reader := csv.NewReader(strings.NewReader(doc))
+	reader.Comma = ' '
+	reader.TrimLeadingSpace = true
 
 	var oo []UR
 


### PR DESCRIPTION
A method was needed to allow for parsing of files that are delimited by a char other than a comma.

A function was added to inject a `*csv.Reader` for unmarshalling instead of a `[]byte`.  This allows for greater flexibility of the package.